### PR TITLE
切换标题栏的实现从自定义实现到原生navigation实现

### DIFF
--- a/TaroWebContainer/src/main/ets/components/BaseCapsule.ets
+++ b/TaroWebContainer/src/main/ets/components/BaseCapsule.ets
@@ -1,5 +1,5 @@
 import { RouterUtils } from '../utils/RouterUtils';
-import { NavigationBar, NavigationBarData } from '../components/NavigationBar';
+import { NavigationBarData } from '../components/NavigationBar';
 
 @Component
 export struct BaseCapsule {
@@ -19,9 +19,9 @@ export struct BaseCapsule {
 
   build() {
     Column() {
-      NavigationBar({
-        navigationBarData: this.navigationBarData,
-      })
+      // NavigationBar({
+      //   navigationBarData: this.navigationBarData,
+      // })
       Column(){
         List(){
           ListItem(){

--- a/TaroWebContainer/src/main/ets/components/BaseDeveloper.ets
+++ b/TaroWebContainer/src/main/ets/components/BaseDeveloper.ets
@@ -1,5 +1,5 @@
 import router from '@ohos.router'
-import { NavigationBar, NavigationBarData } from '../components/NavigationBar'
+import { NavigationBarData } from '../components/NavigationBar'
 
 @Component
 export struct BaseDeveloper {
@@ -23,9 +23,9 @@ export struct BaseDeveloper {
 
   build() {
     Column() {
-      NavigationBar({
-        navigationBarData: this.navigationBarData
-      })
+      // NavigationBar({
+      //   navigationBarData: this.navigationBarData
+      // })
       Scroll(){
         Column({space: 10}){
           Row({space: 10}){

--- a/TaroWebContainer/src/main/ets/components/NavigationBar.ets
+++ b/TaroWebContainer/src/main/ets/components/NavigationBar.ets
@@ -12,10 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import router from '@ohos.router';
-
-const DEFAULT_TITLE_LEFT = 40;
-
 @Observed
 export class NavigationBarData {
   public title: string = '';
@@ -31,63 +27,3 @@ export class NavigationBarData {
   public paddingBottom: number = 8;
 }
 
-/**
- * NavigationBar，自定义导航栏
- */
-@Component
-export struct NavigationBar {
-  @ObjectLink navigationBarData: NavigationBarData;
-  onBackPressed?: ()=>void;
-  // @Consume routerController: RouterController;
-
-  build() {
-    if (this.navigationBarData.visible) {
-      Column() {
-        Row() {
-          if (this.navigationBarData.canBackward) {
-            Image($r('app.media.back'))
-              .fillColor(this.navigationBarData.barFrontColor)
-              .width(25)
-              .height(25)
-              .margin({ left: 26 })
-              .objectFit(ImageFit.Contain)
-              .onClick(() => {
-                if (this.onBackPressed) {
-                  this.onBackPressed();
-                } else {
-                  router.back()
-                }
-              })
-              .id('backBtn')
-          }
-          Text(this.navigationBarData.title)
-            .fontSize(20)
-            .margin({ left: this.navigationBarData.canBackward ? 0 : DEFAULT_TITLE_LEFT })
-            .align(Alignment.Start)
-          if (this.navigationBarData.loading) {
-            LoadingProgress()
-              .width(25)
-              .height(25)
-              .margin({ left: 5 })
-              .foregroundColor(this.navigationBarData.barFrontColor)
-          }
-          Blank()
-        }
-        .height(this.navigationBarData.titleHeight + this.navigationBarData.paddingBottom + this.navigationBarData.systemBarHeight)
-        .width('100%')
-        .alignItems(VerticalAlign.Bottom)
-        .padding({ bottom: this.navigationBarData.paddingBottom })
-      }
-      .backgroundColor(this.navigationBarData.barColor)
-      .foregroundColor(this.navigationBarData.barFrontColor)
-      .animation({
-        duration: this.navigationBarData.animationDuration,
-        curve: this.navigationBarData.animationCurve,
-        delay: 0,
-        iterations: 1,
-        playMode: PlayMode.Normal
-      })
-      .justifyContent(FlexAlign.End)
-    }
-  }
-}

--- a/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
+++ b/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
@@ -18,7 +18,6 @@ import window from '@ohos.window';
 import common from '@ohos.app.ability.common';
 import bundleManager from '@ohos.bundle.bundleManager';
 import { AdvancedAPI } from '@ohos/advanced-api';
-import { NavigationBar } from './navigationbar';
 import { TaroWeb } from './taroweb';
 import { ApiAdapter } from '../inject_adapter/ApiAdapter'
 import { NativeInject  } from '../inject_adapter/NativeInject';
@@ -35,7 +34,7 @@ import router from '@ohos.router';
 import { wbLogger } from '../utils/Logger';
 
 const CONTAINER_TAG = 'TaroWebContainer';
-
+const DEFAULT_TITLE_LEFT = 40;
 
 // import { TaroWebController } from './TaroWeb';
 
@@ -59,11 +58,15 @@ export struct TaroWebContainer {
   // 监听UIAbility的Want
   @Prop @Watch('onWantUpdated') want: Want;
   // 导航栏状态控制器
-  @State navigationBarData: NavigationBarData = new NavigationBarData();
+  @State @Watch('onNavigationStateUpdated') navigationBarData: NavigationBarData = new NavigationBarData();
   // 记录web当前的url
   @State currentUrl: string = '';
   // 系统状态状态栏高度
   @State systemBarHeight: number = 0;
+  // 导航栏高度
+  @State navigationBarHeight: number = 0;
+  // 导航栏可见性
+  @State navigationBarVisible: boolean =  true;
 
   // 路由控制器
   // @Provide routerController: RouterController = new RouterController();
@@ -104,39 +107,95 @@ export struct TaroWebContainer {
     }
   }
 
+  @Builder
+  customNavigationBar() {
+    Column() {
+      Row() {
+        if (this.navigationBarData.canBackward) {
+          Image($r('app.media.back'))
+            .width(25)
+            .height(25)
+            .margin({ left: 26 })
+            .objectFit(ImageFit.Contain)
+            .onClick(() => {
+              this.taroWebController.backward();
+              this.navigationBarData.loading= false;
+            })
+            .id('backBtn')
+        }
+        Text(this.navigationBarData.title)
+          .fontSize(20)
+          .margin({ left: this.navigationBarData.canBackward ? 0 : DEFAULT_TITLE_LEFT })
+          .align(Alignment.Start)
+        if (this.navigationBarData.loading) {
+          LoadingProgress()
+            .width(25)
+            .height(25)
+            .margin({ left: 5 })
+            .foregroundColor(this.navigationBarData.barFrontColor)
+        }
+        Blank()
+      }
+      .width('100%')
+      .height('100%')
+      .alignItems(VerticalAlign.Bottom)
+      .padding({ bottom: this.navigationBarData.paddingBottom })
+    }
+    .width('100%')
+    .height('100%')
+    .foregroundColor(this.navigationBarData.barFrontColor)
+    .backgroundColor(this.navigationBarData.barColor)
+    .animation({
+      duration: this.navigationBarData.animationDuration,
+      curve: this.navigationBarData.animationCurve,
+      delay: 0,
+      iterations: 1,
+      playMode: PlayMode.Normal
+    })
+    .justifyContent(FlexAlign.End)
+  }
 
   build() {
-    Stack({ alignContent: Alignment.TopEnd }) {
-      TaroWeb({
-        src: this.currentUrl,
-        currentUrl: this.currentUrl,
-        apiAdapter: this.adapter,
-        useBuildIn: this.useBuildIn,
-        entryDomain: this.entryDomain,
-        taroWebController: this.taroWebController,
-        onTitleReceive: this.onTitleReceive,
-        onRefreshAccessedHistory: this.onRefreshAccessedHistory
-      })
-      NavigationBar({
-        navigationBarData: this.navigationBarData,
-        onBackPressed: this.onNavigationBarBackPressed
-      })
-      if(this.showCapsule) {
-        Image($r("app.media.capsule"))
-          .margin({ top: (this.isFullScreen ? this.systemBarHeight : 0) + this.capsuleOptions.height - 25, right: this.capsuleOptions.marginRight })
-          .fillColor(this.navigationBarData.barFrontColor)
-          .width(this.capsuleOptions.width)
-          .height(25)
-          .borderRadius(10)
-          .borderColor('#40cccccc')
-          .borderWidth(1)
-          .backgroundColor(this.navigationBarData.barFrontColor === '#ffffff' ? '#30000000' : '#9affffff')
-          .objectFit(ImageFit.Contain)
-          .onClick(() => {
-            RouterUtils.pushUrlWithLog(this.capsulePage)
-          })
-      }
-    }.layoutWeight(1)
+    Navigation() {
+      Stack({ alignContent: Alignment.TopEnd }) {
+        TaroWeb({
+          src: this.currentUrl,
+          currentUrl: this.currentUrl,
+          apiAdapter: this.adapter,
+          useBuildIn: this.useBuildIn,
+          entryDomain: this.entryDomain,
+          taroWebController: this.taroWebController,
+          onTitleReceive: this.onTitleReceive,
+          onRefreshAccessedHistory: this.onRefreshAccessedHistory
+        })
+
+        if (this.showCapsule) {
+          Image($r("app.media.capsule"))
+            .margin({
+              top: (this.isFullScreen ? this.systemBarHeight : 0) + this.capsuleOptions.height - 25,
+              right: this.capsuleOptions.marginRight
+            })
+            .fillColor(this.navigationBarData.barFrontColor)
+            .width(this.capsuleOptions.width)
+            .height(25)
+            .borderRadius(10)
+            .borderColor('#40cccccc')
+            .borderWidth(1)
+            .backgroundColor(this.navigationBarData.barFrontColor === '#ffffff' ? '#30000000' : '#9affffff')
+            .objectFit(ImageFit.Contain)
+            .onClick(() => {
+              RouterUtils.pushUrlWithLog(this.capsulePage)
+            })
+        }
+      }.layoutWeight(1)
+    }
+    .title({ builder: this.customNavigationBar(), height: this.navigationBarHeight})
+    .titleMode(NavigationTitleMode.Mini)
+    .mode(NavigationMode.Stack)
+    .hideTitleBar(!this.navigationBarVisible)
+    .width('100%')
+    .height('100%')
+    .backgroundColor('white')
   }
 
   aboutToAppear() {
@@ -172,7 +231,12 @@ export struct TaroWebContainer {
       nativeInject.setWindowWidth(getWindowWidth(windowClass));
       this.adapter!.setLaunchOptions(this.launchOptions);
       this.adapter!.setNavigationBarHeight(this.systemBarHeight + this.navigationBarData.titleHeight + this.navigationBarData.paddingBottom);
+      this.navigationBarHeight = this.systemBarHeight + this.navigationBarData.titleHeight + this.navigationBarData.paddingBottom;
     })
+  }
+
+  onNavigationStateUpdated() {
+    this.navigationBarVisible = this.navigationBarData.visible;
   }
 
   onPageStateUpdated(): void {

--- a/TaroWebContainer/src/main/ets/inject_adapter/NativeInject.ets
+++ b/TaroWebContainer/src/main/ets/inject_adapter/NativeInject.ets
@@ -156,7 +156,13 @@ export class NativeInject {
         })
       },
       setNavigationStyle: (style, textStyle, backgroundColor) => {
-        this.navigationBarData.visible = style !== 'custom';
+        if(style == 'custom'){
+          setTimeout(() => {
+            this.navigationBarData.visible = style !== 'custom';
+          }, 500);
+        }else {
+          this.navigationBarData.visible = style !== 'custom';
+        }
         this.navigationBarData.barFrontColor = textStyle === 'white' ? '#ffffff' : '#000000';
         this.navigationBarData.barColor = backgroundColor;
         this.navigationBarData.animationDuration = 0;


### PR DESCRIPTION
由于标题栏的实现原来是通过多组件组合成自实现的navigation，在ArkUI中有原生导航栏Navigation，所以尝试修改原自定义实现为原生实现。

结论：
导航栏的控制都和之前保持一致，包括显示/隐藏加载图标，设置标题文字内容，更改导航栏的颜色和显示隐藏导航栏。

存在的问题：
由于布局方式从层叠布局切换为上下布局（Naviagtion是上下布局），导致隐藏导航栏的时候webview的显示范围变大，底部的tabbar区域出现闪动的问题，暂未找到解决方案。

请评估此实现方案。