### PR TITLE
feat: 新增原生方法copyFileToSandboxCache，支持将file://开头文件复制到应用沙盒cache路径下并返回沙盒路径

### DIFF
--- a/TaroWebContainer/src/main/ets/inject_adapter/NativeInject.ets
+++ b/TaroWebContainer/src/main/ets/inject_adapter/NativeInject.ets
@@ -18,6 +18,7 @@ import common from '@ohos.app.ability.common'
 import { BusinessError } from '@ohos.base'
 import Want from '@ohos.app.ability.Want'
 import bundleManager from '@ohos.bundle.bundleManager';
+import fs from '@ohos.file.fs';
 import { InnerInjectObj, MenuButtonOptions, ErrorMsg, PermissionInfo } from '../interfaces/InjectObject'
 import {
   getBundleUsedPermission,
@@ -28,6 +29,7 @@ import {
 import { NavigationBarData } from '../components/NavigationBar';
 import { setSystemBarProperties } from '../utils/WindowUtil';
 import { wbLogger } from '../utils/Logger';
+import { switchHapSandBoxToInternal } from '../utils/InternalPath'
 
 const NATIVE_TAG = 'NativeInject';
 
@@ -76,6 +78,14 @@ export class NativeInject {
 
   public buildInjectObj(): InnerInjectObj {
     return {
+      copyFileToSandboxCache: (src: string) => {
+        const context = getContext() as common.UIAbilityContext;
+        const fileName = src.substring(src.lastIndexOf('/') + 1);
+        const sandboxPath = `${context.cacheDir}/${Date.now()}_${fileName}`;
+        const fd = fs.openSync(src, fs.OpenMode.READ_ONLY).fd;
+        fs.copyFileSync(fd, sandboxPath);
+        return { internalCachePath: switchHapSandBoxToInternal(sandboxPath)}
+      },
       setNavigationBarColor: (options) => {
         wbLogger.info(NATIVE_TAG, `setNavigationBarColor: ${JSON.stringify(options || {})}`)
         this.navigationBarData.barColor = options.backgroundColor ?? this.navigationBarData.barColor;

--- a/TaroWebContainer/src/main/ets/interfaces/InjectObject.ts
+++ b/TaroWebContainer/src/main/ets/interfaces/InjectObject.ts
@@ -146,6 +146,10 @@ export interface GetSettingRetOptions {
   errMsg: string;
 }
 
+export interface copyFileToSandboxCacheRetOptions {
+  internalCachePath: string
+}
+
 interface OpenSettingOptions {
   withSubscriptions?: boolean;
 }
@@ -159,6 +163,7 @@ export interface InnerInjectObj {
   setNavigationStyle: (style: string, textStyle: string, backgroundColor: string) => void;
   openSetting: (options: OpenSettingOptions) => Promise<OpenSettingRetOptions>;
   getSetting: (options: OpenSettingOptions) => Promise<GetSettingRetOptions>;
+  copyFileToSandboxCache: (src: string) => copyFileToSandboxCacheRetOptions;
 }
 
 export interface InjectObject {

--- a/TaroWebContainer/src/main/ets/utils/InternalPath.ts
+++ b/TaroWebContainer/src/main/ets/utils/InternalPath.ts
@@ -39,3 +39,31 @@ export function switchInternalToHapSandBox(path :string) {
     }
     return path
 }
+
+/**
+ * 沙盒路径转internal路径
+ */
+export function switchHapSandBoxToInternal(path :string) {
+    if(path.startsWith(globalThis.abilityContext.bundleCodeDir)){
+        return path.replace(globalThis.abilityContext.bundleCodeDir, 'internal://bundle')
+    }
+    if(path.startsWith(globalThis.abilityContext.cacheDir)){
+        return path.replace(globalThis.abilityContext.cacheDir, 'internal://cache')
+    }
+    if(path.startsWith(globalThis.abilityContext.filesDir)){
+        return path.replace(globalThis.abilityContext.filesDir, 'internal://files')
+    }
+    if(path.startsWith(globalThis.abilityContext.preferencesDir)){
+        return path.replace(globalThis.abilityContext.preferencesDir, 'internal://preferences')
+    }
+    if(path.startsWith(globalThis.abilityContext.tempDir)){
+        return path.replace(globalThis.abilityContext.tempDir, 'internal://temp')
+    }
+    if(path.startsWith(globalThis.abilityContext.databaseDir)){
+        return path.replace(globalThis.abilityContext.databaseDir, 'internal://database')
+    }
+    if(path.startsWith(globalThis.abilityContext.distributedFilesDir)){
+        return path.replace(globalThis.abilityContext.distributedFilesDir, 'internal://distributedFiles')
+    }
+    return path
+}


### PR DESCRIPTION
 新增原生方法copyFileToSandboxCache，支持将file://开头文件复制到应用沙盒cache路径下并返回沙盒路径