### PR TITLE
Native API缓存优化

### DIFF
--- a/TaroWebContainer/Index.ets
+++ b/TaroWebContainer/Index.ets
@@ -1,7 +1,7 @@
 export { TaroWebContainer } from './src/main/ets/components/TaroWebContainer'
 export { BaseCapsule } from './src/main/ets/components/BaseCapsule'
 export { NavigationBar, NavigationBarData } from './src/main/ets/components/NavigationBar'
-export { InjectObject } from './src/main/ets/interfaces/InjectObject'
+export { InjectObject, NativeDataChangeListener } from './src/main/ets/interfaces/InjectObject'
 export { HostPageState } from './src/main/ets/interfaces/HostPageState'
 export { TaroWebController, InterceptRequestHandler } from './src/main/ets/components/TaroWeb'
 export { LocalUpdateManagerInstance } from './src/main/ets/update/LocalUpdateManager'
@@ -14,5 +14,5 @@ export { TaroHybridManager } from './src/main/ets/tarohybrid/TaroHybridManager'
 export { TaroHybrid } from './src/main/ets/tarohybrid/TaroHybrid'
 export { Storage } from './src/main/ets/utils/Storage'
 export { sameLayerManager } from './src/main/ets/utils/SameLayerManager'
-
+export { NativeCacheManager, NativeApiPair, NativeRegister } from './src/main/ets/inject_adapter/NativeCacheManager'
 

--- a/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
+++ b/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
@@ -296,7 +296,7 @@ export struct TaroWebContainer {
     this.appearDone = true;
 
     this.taroWebController.getNativeCacheManager().initCacheData(context)
-    this.taroWebController.getNativeCacheManager().register([new GetWindowInfoCache(), new GetDeviceInfoCache(), new GetSystemSettingCache()])
+    this.taroWebController.getNativeCacheManager().register(new GetWindowInfoCache(), new GetDeviceInfoCache(), new GetSystemSettingCache())
 
   }
 

--- a/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
+++ b/TaroWebContainer/src/main/ets/components/TaroWebContainer.ets
@@ -295,7 +295,7 @@ export struct TaroWebContainer {
     })
     this.appearDone = true;
 
-    this.taroWebController.getNativeCacheManager().init(context)
+    this.taroWebController.getNativeCacheManager().initCacheData(context)
     this.taroWebController.getNativeCacheManager().register([new GetWindowInfoCache(), new GetDeviceInfoCache(), new GetSystemSettingCache()])
 
   }

--- a/TaroWebContainer/src/main/ets/inject_adapter/NativeCacheManager.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/NativeCacheManager.ts
@@ -58,7 +58,7 @@ export class NativeCacheManager {
     }
     let rNameList = new Set<string>()
     this._unUpdaterRegisters.forEach(r => {
-      this._registers.push(r)
+      this._registers.indexOf(r) === -1 && this._registers.push(r)
       r.updater(this._context, () => this._listener)
       rNameList.add(r.method)
     })

--- a/TaroWebContainer/src/main/ets/inject_adapter/NativeCacheManager.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/NativeCacheManager.ts
@@ -62,9 +62,9 @@ export class NativeCacheManager {
       r.updater(this._context, () => this._listener)
       rNameList.add(r.method)
     })
+    this._unUpdaterRegisters.splice(0)
     // taro注册
     this._listener?.register(Array.from(rNameList))
-    this._unUpdaterRegisters.splice(0)
   }
 
   /**

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetDeviceInfoCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetDeviceInfoCache.ts
@@ -1,8 +1,9 @@
 import { NativeApiPair, NativeRegister } from '../NativeCacheManager';
 import { common } from '@kit.AbilityKit';
-import { window } from '@kit.ArkUI';
+import { Size, window } from '@kit.ArkUI';
 import { taroLogger } from '../../utils/Logger';
 import { NativeDataChangeListener } from '../../interfaces/InjectObject';
+import { Callback } from '@kit.BasicServicesKit';
 
 /**
  * 注册NativeApi方法"getDeviceInfo"的监听
@@ -14,29 +15,47 @@ export class GetDeviceInfoCache implements NativeRegister {
   }
   private TAG = this.pair.method
 
-  method: string;
-  args: any[];
-  updater: (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => void;
+  private callback: Callback<Size>
 
-  constructor() {
-    this.method = this.pair.method
-    this.args = this.pair.args
-    this.updater = (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => {
-      try {
-        window.getLastWindow(context).then((windowClass) => {
-          // 屏幕的监听
-          try {
-            windowClass && windowClass.on('windowSizeChange', (data) => {
-              taroLogger.debug(this.TAG, "windowScreenChange:" + JSON.stringify(data))
-              listener()?.change(this.pair.method, this.pair.args)
-            });
-          } catch (exception) {
-            taroLogger.debug(this.TAG, "windowScreenChange failed Cause:" + JSON.stringify(exception))
-          }
-        })
-      } catch (e) {
-        taroLogger.debug(this.TAG, `registerGetWindowInfo发生错误`)
+  getMethod(): string {
+    return this.pair.method
+  }
+
+  getArgs(): any[] {
+    return this.pair.args
+  }
+
+  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
+    try {
+
+      this.callback = (data) => {
+        taroLogger.debug(this.TAG, "windowScreenChange:" + JSON.stringify(data))
+        listener()?.change(this.pair.method, this.pair.args)
       }
+
+      window.getLastWindow(context).then((windowClass) => {
+        // 屏幕的监听
+        try {
+          windowClass && windowClass.on('windowSizeChange', this.callback);
+        } catch (exception) {
+          taroLogger.debug(this.TAG, "windowScreenChange failed Cause:" + JSON.stringify(exception))
+        }
+      })
+    } catch (e) {
+      taroLogger.debug(this.TAG, `registerGetWindowInfo发生错误`)
+    }
+  }
+
+  dispose(context: common.UIAbilityContext): void {
+    if (this.callback) {
+      window.getLastWindow(context).then((windowClass) => {
+        // 屏幕的监听
+        try {
+          windowClass && windowClass.off('windowSizeChange', this.callback);
+        } catch (exception) {
+          taroLogger.debug(this.TAG, "windowScreenChange failed Cause:" + JSON.stringify(exception))
+        }
+      })
     }
   }
 }

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetDeviceInfoCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetDeviceInfoCache.ts
@@ -2,13 +2,13 @@ import { NativeApiPair, NativeRegister } from '../NativeCacheManager';
 import { common } from '@kit.AbilityKit';
 import { Size, window } from '@kit.ArkUI';
 import { taroLogger } from '../../utils/Logger';
-import { NativeDataChangeListener } from '../../interfaces/InjectObject';
 import { Callback } from '@kit.BasicServicesKit';
 
 /**
  * 注册NativeApi方法"getDeviceInfo"的监听
  */
 export class GetDeviceInfoCache implements NativeRegister {
+
   private pair: NativeApiPair = {
     method: "getDeviceInfo",
     args: []
@@ -17,33 +17,29 @@ export class GetDeviceInfoCache implements NativeRegister {
 
   private callback: Callback<Size>
 
-  getMethod(): string {
-    return this.pair.method
+  getApis(): NativeApiPair[] {
+    return [this.pair]
   }
 
-  getArgs(): any[] {
-    return this.pair.args
-  }
+  updater(context: common.UIAbilityContext, onChange: (apiPairs: NativeApiPair[]) => void): void {
+      try {
 
-  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
-    try {
-
-      this.callback = (data) => {
-        taroLogger.debug(this.TAG, "windowScreenChange:" + JSON.stringify(data))
-        listener()?.change(this.pair.method, this.pair.args)
-      }
-
-      window.getLastWindow(context).then((windowClass) => {
-        // 屏幕的监听
-        try {
-          windowClass && windowClass.on('windowSizeChange', this.callback);
-        } catch (exception) {
-          taroLogger.debug(this.TAG, "windowScreenChange failed Cause:" + JSON.stringify(exception))
+        this.callback = (data) => {
+          taroLogger.debug(this.TAG, "windowScreenChange:" + JSON.stringify(data))
+          onChange([this.pair])
         }
-      })
-    } catch (e) {
-      taroLogger.debug(this.TAG, `registerGetWindowInfo发生错误`)
-    }
+
+        window.getLastWindow(context).then((windowClass) => {
+          // 屏幕的监听
+          try {
+            windowClass && windowClass.on('windowSizeChange', this.callback);
+          } catch (exception) {
+            taroLogger.debug(this.TAG, "windowScreenChange failed Cause:" + JSON.stringify(exception))
+          }
+        })
+      } catch (e) {
+        taroLogger.debug(this.TAG, `registerGetWindowInfo发生错误`)
+      }
   }
 
   dispose(context: common.UIAbilityContext): void {

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetSystemSettingCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetSystemSettingCache.ts
@@ -1,16 +1,16 @@
 import { NativeApiPair, NativeRegister } from '../NativeCacheManager';
 import { abilityAccessCtrl, common, Permissions } from '@kit.AbilityKit';
+import { geoLocationManager } from '@kit.LocationKit';
+import { BusinessError, Callback } from '@kit.BasicServicesKit';
 import { access, wifiManager } from '@kit.ConnectivityKit';
 import { taroLogger } from '../../utils/Logger';
-import { geoLocationManager } from '@kit.LocationKit';
 import { mediaquery } from '@kit.ArkUI';
-import { BusinessError, Callback } from '@kit.BasicServicesKit';
-import { NativeDataChangeListener } from '../../interfaces/InjectObject';
 
 /**
  * 注册NativeApi方法"getSystemSetting"的监听
  */
 export class GetSystemSettingCache implements NativeRegister {
+
   private pair: NativeApiPair = {
     method: "getSystemSetting",
     args: []
@@ -19,79 +19,74 @@ export class GetSystemSettingCache implements NativeRegister {
 
   private locationEnabledChangeCallback: Callback<boolean>
 
-  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
-    try {
-      // wifi状态的监听
-      wifiManager.on("wifiStateChange", (result: number) => {
-        //0: inactive, 1: active, 2: activating, 3: de-activating
-        taroLogger.debug(this.TAG, "wifiStateChange:" + result)
-        if (result === 1) {
-          listener()?.change(this.pair.method, this.pair.args)
-        } else if (result === 0) {
-          listener()?.change(this.pair.method, this.pair.args)
-        }
-      });
+  getApis(): NativeApiPair[] {
+    return [this.pair]
+  }
 
-      this.locationEnabledChangeCallback = (state: boolean): void => {
-        taroLogger.debug(this.TAG, "locationEnabledChange:" + JSON.stringify(state))
-        listener()?.change(this.pair.method, this.pair.args)
-      }
-
-      // 地理位置的系统开关监听
-      geoLocationManager.on('locationEnabledChange', this.locationEnabledChangeCallback);
-
-      // 横竖屏的监听
-      mediaquery.matchMediaSync('(orientation: landscape)')
-        .on("change", (mediaQueryResult: mediaquery.MediaQueryResult) => {
-          let matches = mediaQueryResult.matches as boolean
-          taroLogger.debug(this.TAG, "orientation: landscape:" + matches)
-          listener()?.change(this.pair.method, this.pair.args)
-        })
-
-      // 蓝牙的监听
-      let permissions: Array<Permissions> = ['ohos.permission.ACCESS_BLUETOOTH'];
-      let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
-      // requestPermissionsFromUser会判断权限的授权状态来决定是否唤起弹窗
-      atManager.requestPermissionsFromUser(context, permissions).then((data) => {
-        let grantStatus: Array<number> = data.authResults;
-        let length: number = grantStatus.length;
-        for (let i = 0; i < length; i++) {
-          if (grantStatus[i] === 0) {
-            // 用户授权，可以继续访问目标操作
-            access.on('stateChange', (data: access.BluetoothState) => {
-              taroLogger.debug(this.TAG, "bluetoothStateChange:" + JSON.stringify(data))
-              if (data === access.BluetoothState.STATE_OFF) {
-                listener()?.change(this.pair.method, this.pair.args)
-              } else if (data === access.BluetoothState.STATE_ON) {
-                listener()?.change(this.pair.method, this.pair.args)
-              }
-            });
-          } else {
-            // 用户拒绝授权，提示用户必须授权才能访问当前页面的功能，并引导用户到系统设置中打开相应的权限
-            return;
+  updater(context: common.UIAbilityContext, onChange: (apiPairs: NativeApiPair[]) => void): void {
+      try {
+        // wifi状态的监听
+        wifiManager.on("wifiStateChange", (result: number) => {
+          //0: inactive, 1: active, 2: activating, 3: de-activating
+          taroLogger.debug(this.TAG, "wifiStateChange:" + result)
+          if (result === 1) {
+            onChange([this.pair])
+          } else if (result === 0) {
+            onChange([this.pair])
           }
+        });
+
+        this.locationEnabledChangeCallback = (state: boolean): void => {
+          taroLogger.debug(this.TAG, "locationEnabledChange:" + JSON.stringify(state))
+          onChange([this.pair])
         }
-        // 授权成功
-      }).catch((err: BusinessError) => {
-        taroLogger.debug(this.TAG, `Failed to request permissions from user. Code is ${err.code}, message is ${err.message}`)
-      })
-    } catch (e) {
-      taroLogger.debug(this.TAG, `registerGetSystemSetting发生错误`)
-    }
+
+        // 地理位置的系统开关监听
+        geoLocationManager.on('locationEnabledChange', this.locationEnabledChangeCallback);
+
+        // 横竖屏的监听
+        mediaquery.matchMediaSync('(orientation: landscape)')
+          .on("change", (mediaQueryResult: mediaquery.MediaQueryResult) => {
+            let matches = mediaQueryResult.matches as boolean
+            taroLogger.debug(this.TAG, "orientation: landscape:" + matches)
+            onChange([this.pair])
+          })
+
+        // 蓝牙的监听
+        let permissions: Array<Permissions> = ['ohos.permission.ACCESS_BLUETOOTH'];
+        let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
+        // requestPermissionsFromUser会判断权限的授权状态来决定是否唤起弹窗
+        atManager.requestPermissionsFromUser(context, permissions).then((data) => {
+          let grantStatus: Array<number> = data.authResults;
+          let length: number = grantStatus.length;
+          for (let i = 0; i < length; i++) {
+            if (grantStatus[i] === 0) {
+              // 用户授权，可以继续访问目标操作
+              access.on('stateChange', (data: access.BluetoothState) => {
+                taroLogger.debug(this.TAG, "bluetoothStateChange:" + JSON.stringify(data))
+                if (data === access.BluetoothState.STATE_OFF) {
+                  onChange([this.pair])
+                } else if (data === access.BluetoothState.STATE_ON) {
+                  onChange([this.pair])
+                }
+              });
+            } else {
+              // 用户拒绝授权，提示用户必须授权才能访问当前页面的功能，并引导用户到系统设置中打开相应的权限
+              return;
+            }
+          }
+          // 授权成功
+        }).catch((err: BusinessError) => {
+          taroLogger.debug(this.TAG, `Failed to request permissions from user. Code is ${err.code}, message is ${err.message}`)
+        })
+      } catch (e) {
+        taroLogger.debug(this.TAG, `registerGetSystemSetting发生错误`)
+      }
   }
 
   dispose(context: common.UIAbilityContext): void {
     // 地理位置的系统开关监听
     this.locationEnabledChangeCallback && geoLocationManager.off('locationEnabledChange', this.locationEnabledChangeCallback);
   }
-
-  getMethod(): string {
-    return this.pair.method
-  }
-
-  getArgs(): any[] {
-    throw this.pair.args
-  }
-
 
 }

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetSystemSettingCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetSystemSettingCache.ts
@@ -4,7 +4,7 @@ import { access, wifiManager } from '@kit.ConnectivityKit';
 import { taroLogger } from '../../utils/Logger';
 import { geoLocationManager } from '@kit.LocationKit';
 import { mediaquery } from '@kit.ArkUI';
-import { BusinessError } from '@kit.BasicServicesKit';
+import { BusinessError, Callback } from '@kit.BasicServicesKit';
 import { NativeDataChangeListener } from '../../interfaces/InjectObject';
 
 /**
@@ -17,70 +17,81 @@ export class GetSystemSettingCache implements NativeRegister {
   }
   private TAG = this.pair.method
 
-  method: string;
-  args: any[];
-  updater: (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => void;
+  private locationEnabledChangeCallback: Callback<boolean>
 
-  constructor() {
-    this.method = this.pair.method
-    this.args = this.pair.args
-    this.updater = (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => {
-      try {
-        // wifi状态的监听
-        wifiManager.on("wifiStateChange", (result: number) => {
-          //0: inactive, 1: active, 2: activating, 3: de-activating
-          taroLogger.debug(this.TAG, "wifiStateChange:" + result)
-          if (result === 1) {
-            listener()?.change(this.pair.method, this.pair.args)
-          } else if (result === 0) {
-            listener()?.change(this.pair.method, this.pair.args)
-          }
-        });
-
-        // 地理位置的系统开关监听
-        geoLocationManager.on('locationEnabledChange', (state: boolean): void => {
-          taroLogger.debug(this.TAG, "locationEnabledChange:" + JSON.stringify(state))
+  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
+    try {
+      // wifi状态的监听
+      wifiManager.on("wifiStateChange", (result: number) => {
+        //0: inactive, 1: active, 2: activating, 3: de-activating
+        taroLogger.debug(this.TAG, "wifiStateChange:" + result)
+        if (result === 1) {
           listener()?.change(this.pair.method, this.pair.args)
-        });
+        } else if (result === 0) {
+          listener()?.change(this.pair.method, this.pair.args)
+        }
+      });
 
-        // 横竖屏的监听
-        mediaquery.matchMediaSync('(orientation: landscape)')
-          .on("change", (mediaQueryResult: mediaquery.MediaQueryResult) => {
-            let matches = mediaQueryResult.matches as boolean
-            taroLogger.debug(this.TAG, "orientation: landscape:" + matches)
-            listener()?.change(this.pair.method, this.pair.args)
-          })
-
-        // 蓝牙的监听
-        let permissions: Array<Permissions> = ['ohos.permission.ACCESS_BLUETOOTH'];
-        let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
-        // requestPermissionsFromUser会判断权限的授权状态来决定是否唤起弹窗
-        atManager.requestPermissionsFromUser(context, permissions).then((data) => {
-          let grantStatus: Array<number> = data.authResults;
-          let length: number = grantStatus.length;
-          for (let i = 0; i < length; i++) {
-            if (grantStatus[i] === 0) {
-              // 用户授权，可以继续访问目标操作
-              access.on('stateChange', (data: access.BluetoothState) => {
-                taroLogger.debug(this.TAG, "bluetoothStateChange:" + JSON.stringify(data))
-                if (data === access.BluetoothState.STATE_OFF) {
-                  listener()?.change(this.pair.method, this.pair.args)
-                } else if (data === access.BluetoothState.STATE_ON) {
-                  listener()?.change(this.pair.method, this.pair.args)
-                }
-              });
-            } else {
-              // 用户拒绝授权，提示用户必须授权才能访问当前页面的功能，并引导用户到系统设置中打开相应的权限
-              return;
-            }
-          }
-          // 授权成功
-        }).catch((err: BusinessError) => {
-          taroLogger.debug(this.TAG, `Failed to request permissions from user. Code is ${err.code}, message is ${err.message}`)
-        })
-      } catch (e) {
-        taroLogger.debug(this.TAG, `registerGetSystemSetting发生错误`)
+      this.locationEnabledChangeCallback = (state: boolean): void => {
+        taroLogger.debug(this.TAG, "locationEnabledChange:" + JSON.stringify(state))
+        listener()?.change(this.pair.method, this.pair.args)
       }
+
+      // 地理位置的系统开关监听
+      geoLocationManager.on('locationEnabledChange', this.locationEnabledChangeCallback);
+
+      // 横竖屏的监听
+      mediaquery.matchMediaSync('(orientation: landscape)')
+        .on("change", (mediaQueryResult: mediaquery.MediaQueryResult) => {
+          let matches = mediaQueryResult.matches as boolean
+          taroLogger.debug(this.TAG, "orientation: landscape:" + matches)
+          listener()?.change(this.pair.method, this.pair.args)
+        })
+
+      // 蓝牙的监听
+      let permissions: Array<Permissions> = ['ohos.permission.ACCESS_BLUETOOTH'];
+      let atManager: abilityAccessCtrl.AtManager = abilityAccessCtrl.createAtManager();
+      // requestPermissionsFromUser会判断权限的授权状态来决定是否唤起弹窗
+      atManager.requestPermissionsFromUser(context, permissions).then((data) => {
+        let grantStatus: Array<number> = data.authResults;
+        let length: number = grantStatus.length;
+        for (let i = 0; i < length; i++) {
+          if (grantStatus[i] === 0) {
+            // 用户授权，可以继续访问目标操作
+            access.on('stateChange', (data: access.BluetoothState) => {
+              taroLogger.debug(this.TAG, "bluetoothStateChange:" + JSON.stringify(data))
+              if (data === access.BluetoothState.STATE_OFF) {
+                listener()?.change(this.pair.method, this.pair.args)
+              } else if (data === access.BluetoothState.STATE_ON) {
+                listener()?.change(this.pair.method, this.pair.args)
+              }
+            });
+          } else {
+            // 用户拒绝授权，提示用户必须授权才能访问当前页面的功能，并引导用户到系统设置中打开相应的权限
+            return;
+          }
+        }
+        // 授权成功
+      }).catch((err: BusinessError) => {
+        taroLogger.debug(this.TAG, `Failed to request permissions from user. Code is ${err.code}, message is ${err.message}`)
+      })
+    } catch (e) {
+      taroLogger.debug(this.TAG, `registerGetSystemSetting发生错误`)
     }
   }
+
+  dispose(context: common.UIAbilityContext): void {
+    // 地理位置的系统开关监听
+    this.locationEnabledChangeCallback && geoLocationManager.off('locationEnabledChange', this.locationEnabledChangeCallback);
+  }
+
+  getMethod(): string {
+    return this.pair.method
+  }
+
+  getArgs(): any[] {
+    throw this.pair.args
+  }
+
+
 }

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetWindowInfoCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetWindowInfoCache.ts
@@ -10,17 +10,20 @@ export class GetWindowInfoCache implements NativeRegister {
     method: "getWindowInfo",
     args: []
   }
-  private TAG = this.pair.method
 
-  method: string;
-  args: any[];
-  updater: (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => void;
+  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
 
-  constructor() {
-    this.method = this.pair.method
-    this.args = this.pair.args
-    this.updater = (context: common.UIAbilityContext | null, listener: () => NativeDataChangeListener | null) => {
-      // 无需更新数据
-    }
+  }
+
+  getMethod(): string {
+    return this.pair.method
+  }
+
+  getArgs(): any[] {
+    return this.pair.args
+  }
+
+  dispose(context: common.UIAbilityContext): void {
+
   }
 }

--- a/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetWindowInfoCache.ts
+++ b/TaroWebContainer/src/main/ets/inject_adapter/nativecache/GetWindowInfoCache.ts
@@ -1,26 +1,22 @@
 import { NativeApiPair, NativeRegister } from '../NativeCacheManager';
 import { common } from '@kit.AbilityKit';
-import { NativeDataChangeListener } from '../../interfaces/InjectObject';
 
 /**
  * 注册NativeApi方法"getWindowInfo"的监听
  */
 export class GetWindowInfoCache implements NativeRegister {
+
   private pair: NativeApiPair = {
     method: "getWindowInfo",
     args: []
   }
 
-  updater(context: common.UIAbilityContext, listener: () => NativeDataChangeListener | null): void {
-
+  getApis(): NativeApiPair[] {
+    return [this.pair]
   }
 
-  getMethod(): string {
-    return this.pair.method
-  }
+  updater(context: common.UIAbilityContext, onChange: (apiPairs: NativeApiPair[]) => void): void {
 
-  getArgs(): any[] {
-    return this.pair.args
   }
 
   dispose(context: common.UIAbilityContext): void {

--- a/TaroWebContainer/src/main/ets/interfaces/InjectObject.ts
+++ b/TaroWebContainer/src/main/ets/interfaces/InjectObject.ts
@@ -209,7 +209,7 @@ export interface NativeDataChangeListener {
    * @param methodName    要更新的方法名
    * @param methodArgs    要更新的方法参数，如果是空参，直接传[]
    */
-  change: (methodName: string, methodArgs: any[]) => void
+  change: (methodName: string, methodArgs: object[]) => void
   /**
    * 注册
    * @param methodName    要注册的方法名列表


### PR DESCRIPTION
1. NativeCacheManager注册方法可随时调用，使上层业务可以注册接口缓存能力，注册方法不再依赖初始化方法顺序
2. NativeRegister接口中的变量修改为方法，增强编码约束力
3. NativeRegister增加dispose方法，用于释放资源、取消监听等
4. NativeRegister接口修改，支持一个NativeRegister类注册多个native api
5. 支持前端注册多个NativeDataChangeListener